### PR TITLE
Document workaround for empty schema

### DIFF
--- a/docs/10-primary-sites/0-introduction.mdx
+++ b/docs/10-primary-sites/0-introduction.mdx
@@ -7,6 +7,10 @@ import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequir
 
 Primary Sites store your robotics data in the cloud, and can be Foxglove- or self-hosted.
 
+Foxglove supports importing either MCAP (.mcap) or ROS 1 bag (.bag) files.
+
+MCAP files imported to Foxglove must define a schema. If you're working with JSON, you may define an [empty JSON Schema](../visualization/message-schemas/introduction#empty-json-schemas).
+
 ### Foxglove-hosted
 
 When you sign up for a Foxglove organization, you are assigned a Foxglove-hosted Primary Site by default. Your organization's data files will be imported to this Primary Site.

--- a/docs/10-primary-sites/0-introduction.mdx
+++ b/docs/10-primary-sites/0-introduction.mdx
@@ -7,10 +7,6 @@ import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequir
 
 Primary Sites store your robotics data in the cloud, and can be Foxglove- or self-hosted.
 
-Foxglove supports importing either MCAP (.mcap) or ROS 1 bag (.bag) files.
-
-MCAP files imported to Foxglove must define a schema. If you're working with JSON, you may define an [empty JSON Schema](../visualization/message-schemas/introduction#empty-json-schemas).
-
 ### Foxglove-hosted
 
 When you sign up for a Foxglove organization, you are assigned a Foxglove-hosted Primary Site by default. Your organization's data files will be imported to this Primary Site.

--- a/docs/3-visualization/2-message-schemas/0-introduction.mdx
+++ b/docs/3-visualization/2-message-schemas/0-introduction.mdx
@@ -32,6 +32,10 @@ We provide WebSocket libraries for live data ([Python](https://github.com/foxglo
 
 _Check out the blog post on [Recording Robocar Data with MCAP](https://foxglove.dev/blog/recording-robocar-data-with-mcap) for an example on using an [MCAP](https://mcap.dev) C++ writer to record your Protobuf data._
 
+### Empty JSON Schemas
+
+MCAP allows empty schemas for the JSON message encoding, but you must define a valid JSON schema for visualization. If you don't want to define your schema, you can specify a JSON Schema representing any object, which by default allows additional properties: `{"type": "object"}`.
+
 ### ROS
 
 Install the [`foxglove_msgs` package](https://index.ros.org/r/foxglove_msgs/):


### PR DESCRIPTION
This documents a limitation of MCAP with data platform (FG-5360) and a workaround for users who would otherwise use an empty MCAP schema. Studio requires that a bare-bones object schema is supplied (if one is supplied at all). As of https://github.com/foxglove/studio/pull/7100, the schema listed here will work.