### PR TITLE
Fix sometimes incorrect message schema links

### DIFF
--- a/src/plugins/foxglove-schemas/generatePages.ts
+++ b/src/plugins/foxglove-schemas/generatePages.ts
@@ -121,15 +121,15 @@ custom_edit_url: ${editUrl}
         let linkText: string;
         switch (field.type.type) {
           case "primitive":
-            linkTarget = `built-in-types#${field.type.name}`;
+            linkTarget = `/docs/visualization/message-schemas/built-in-types#${field.type.name}`;
             linkText = field.type.name;
             break;
           case "nested":
-            linkTarget = `${kebabCase(field.type.schema.name)}`;
+            linkTarget = `/docs/visualization/message-schemas/${kebabCase(field.type.schema.name)}`;
             linkText = field.type.schema.name;
             break;
           case "enum":
-            linkTarget = `${kebabCase(field.type.enum.name)}`;
+            linkTarget = `/docs/visualization/message-schemas/${kebabCase(field.type.enum.name)}`;
             linkText = field.type.enum.name;
             break;
         }


### PR DESCRIPTION
### Public-Facing Changes

BEFORE:
- **Loading the page for a message schema with nested schemas** - click the links, get 404s (unnecessary part in the URL)
- **Navigate to that same page from another one** – click the links, consistently get the correct pages
- **Running locally** – click the links, consistently get the correct pages (regardless of page visit history)

AFTER:
- Use absolute paths for links to get rid of unnecessary parts in URLs
 