### PR TITLE
Add `registerTopicAliases` to extension context docs

### DIFF
--- a/docs/3-visualization/8-extensions/0-introduction.mdx
+++ b/docs/3-visualization/8-extensions/0-introduction.mdx
@@ -81,7 +81,7 @@ export function activate(extensionContext: ExtensionContext) {
 
 ### Topic aliases
 
-The `registerTopicAliases` function accepts two arguments – the data source's original topics and the current layout's global variables – and outputs a list of aliased topics:
+The `registerTopicAliases` function accepts an argument with two fields – `topics` with the data source's original topics and `globalVariables` with current layout's variables – and outputs a list of aliased topics:
 
 ```typescript
 import { ExtensionContext } from "@foxglove/studio";
@@ -90,6 +90,9 @@ export function activate(extensionContext: ExtensionContext): void {
   // Register a topic alias function that takes the current list of datasource topics and
   // global variables and outputs a list of topic aliases.
   extensionContext.registerTopicAliases((args) => {
+    // Use args.topics if you want to access the list of available topics in your data source.
+    // args.topics
+
     const { globalVariables } = args;
     // Output a list of aliased topics, in this case influenced by the current value of
     // the global variable `camera`.

--- a/docs/3-visualization/8-extensions/0-introduction.mdx
+++ b/docs/3-visualization/8-extensions/0-introduction.mdx
@@ -81,7 +81,7 @@ export function activate(extensionContext: ExtensionContext) {
 
 ### Topic aliases
 
-The `registerTopicAliases` function accepts an argument with two fields – `topics` with the data source's original topics and `globalVariables` with current layout's variables – and outputs a list of aliased topics:
+The `registerTopicAliases` function accepts an argument with two fields – `topics` with the data source's original topics and `globalVariables` with the current layout's variables – and returns a list of aliased topics:
 
 ```typescript
 import { ExtensionContext } from "@foxglove/studio";
@@ -91,7 +91,6 @@ export function activate(extensionContext: ExtensionContext): void {
   // global variables and outputs a list of topic aliases.
   extensionContext.registerTopicAliases((args) => {
     // Use args.topics if you want to access the list of available topics in your data source.
-    // args.topics
 
     const { globalVariables } = args;
     // Output a list of aliased topics, in this case influenced by the current value of

--- a/docs/3-visualization/8-extensions/1-api/0-extension-context.mdx
+++ b/docs/3-visualization/8-extensions/1-api/0-extension-context.mdx
@@ -31,9 +31,9 @@ See the [Creating a message converter](/docs/visualization/extensions/guides/cre
 
 ## registerTopicAliases
 
-`registerTopicAliases` register a function to compute topic aliases. The provided alias function
-accepts an argument with two fields – `topics` with the data source's original topics and
-`globalVariables` with current layout's variables – and outputs a list of aliased topics.
+`registerTopicAliases` registers a function to compute topic aliases. The provided alias function
+should accept an argument with two fields – `topics` with the data source's original topics and
+`globalVariables` with the current layout's variables – and return a list of aliased topics.
 
 Your alias function runs whenever there are changes to the data source topics or variables. Any
 aliases it returns are added to the data source topics (replacing any previously returned aliases)

--- a/docs/3-visualization/8-extensions/1-api/0-extension-context.mdx
+++ b/docs/3-visualization/8-extensions/1-api/0-extension-context.mdx
@@ -29,6 +29,16 @@ Whenever a panel subscribes to a topic with the [`convertTo`](/docs/visualizatio
 
 See the [Creating a message converter](/docs/visualization/extensions/guides/create-message-converter) guide for more details.
 
+## registerTopicAliases
+
+`registerTopicAliases` register a function to compute topic aliases. The provided alias function
+accepts an argument with two fields – `topics` with the data source's original topics and
+`globalVariables` with current layout's variables – and outputs a list of aliased topics.
+
+Your alias function runs whenever there are changes to the data source topics or variables. Any
+aliases it returns are added to the data source topics (replacing any previously returned aliases)
+and available for subscribing or use within message paths as if they were real topics.
+
 ## API Reference
 
-- [`@foxglove/studio`](https://github.com/foxglove/studio/blob/main/packages/studio)
+- [`@foxglove/studio`](https://github.com/foxglove/studio/blob/main/packages/studio/src/index.ts)


### PR DESCRIPTION
This api call was missing from the documentation. I've also updated the API reference link for @foxglove/studio to link to the typescript file which IMO is a nicer reference link than the folder with the file.