### PR TITLE
Fix links to parent message schemas

### DIFF
--- a/src/plugins/foxglove-schemas/generatePages.ts
+++ b/src/plugins/foxglove-schemas/generatePages.ts
@@ -109,7 +109,10 @@ custom_edit_url: ${editUrl}
       }\` appears in the ${new Intl.ListFormat().format(
         [...parentTypes]
           .sort()
-          .map((parentType) => `[\`${parentType}\`](${kebabCase(parentType)})`),
+          .map(
+            (parentType) =>
+              `[\`${parentType}\`](/docs/visualization/message-schemas/${kebabCase(parentType)})`,
+          ),
       )} message schema${parentTypes.size > 1 ? "s" : ""}.`,
 
     "## Schema",


### PR DESCRIPTION
### Public-Facing Changes

Fixed broken links to parent schemas in the message schema documentation.

### Description

Fixed by using an absolute instead of relative path.
