### PR TITLE
More Introduction page revisions

### DIFF
--- a/docs/0-introduction.md
+++ b/docs/0-introduction.md
@@ -12,28 +12,20 @@ Foxglove helps robotics teams explore, collaborate on, and make sense of their r
 Foxglove provides a wide array of developer tooling for every step of the robotics development process.
 
 - **Record**
-  - Record multimodal data in a variety of encoding formats (MCAP, ROS 1, ROS 2, Protobuf, etc.)
+  - Record multimodal data in a variety of [supported encoding formats](/docs/connecting-to-data/local-data#supported-formats) ([MCAP](https://mcap.dev), ROS 1, ROS 2, Protobuf, etc.)
 - **Ingest**
-  - Import recordings from local machines and edge sites into a central cloud repository
+  - [Import](/docs/importing-data) recordings from local machines and edge sites into a central cloud repository
 - **Process**
-  - Index the data by device, time, and topic
+  - Index imported [data recordings](/docs/recordings) by device, time, and topic
   - Set retention policies to manage your team's data store
   - Configure webhooks to integrate with the rest of your data pipeline
 - **Visualize**
+  - [Stream imported data](/docs/connecting-to-data/imported-data) to Foxglove and [third-party tools like Jupyter Notebooks](/docs/integrations/jupyter-notebooks) for analysis
   - Configure [panels](/docs/visualization/panels/introduction) to understand how your robots sense, think, and act
   - Create shared [layouts](/docs/visualization/layouts) for tackling repeated visualization and debugging tasks
 - **Collaborate**
   - Annotate logs with [metadata and events](/docs/events) for easier search and discovery
   - Rely on collective knowledge to triage incidents and analyze the root cause of an issue
-
-## Getting started
-
-- Record multimodal data using a variety of [supported encoding formats](/docs/connecting-to-data/local-data#supported-formats)
-  - [MCAP](https://mcap.dev) allows multiple streams of structured and unstructured data in one file (e.g. ROS, Protobuf, JSON Schema, etc.)
-- [Import](/docs/importing-data) local data recordings, organized by timestamp and recording [device](/docs/devices)
-- Annotate [recordings](/docs/recordings) with metadata and [events](/docs/events)
-- Arrange and configure [panels](/docs/visualization/panels/introduction) into custom visualization and debugging [layouts](/docs/visualization/layouts)
-- [Stream imported data](/connecting-to-data/imported-data) to Foxglove and [third-party tools like Jupyter Notebooks](/docs/integrations/jupyter-notebooks) for analysis
 
 ## Links and resources
 


### PR DESCRIPTION
### Public-Facing Changes

- Remove "Getting started" section on the docs intro page (largely a duplicate of the "Workflows" section)
- Fix the streaming docs link