### PR TITLE
Updates docs for deviceless data

### DIFF
--- a/docs/10-primary-sites/1-self-hosting/1-manage-data.md
+++ b/docs/10-primary-sites/1-self-hosting/1-manage-data.md
@@ -5,52 +5,53 @@ description: Manage your self-hosted Primary Site's data.
 
 Manage your self-hosted Primary Site's data.
 
-### Upload data
+### Uploading data
 
-To import data to the platform, self-managed users must upload their recordings
-to the inbox bucket using one of the methods below.
+To import data to Foxglove, self-managed users must upload their recordings to their configured inbox bucket. Once acknowledged, the pending import will appear on the [Recordings page](https://console.foxglove.dev/recordings). Once processed, its data will be available via the [API](/api) and [CLI](/docs/cli).
 
-Once the import is acknowledged by the platform, you will see the pending
-import on the [Recordings page](https://console.foxglove.dev/recordings). Once
-processed, the uploaded data will be available via the API and CLI.
+#### Prevent duplication with idempotency keys
 
-#### Usage note: Idempotency keys
-Foxglove's upload APIs use one of two mechanisms to ensure recordings are
-processed only once, preventing duplicates.
-1. Internally, Foxglove creates a unique idempotency key to avoid duplicates after reception.
-2. For uploaders, if the recording is associated with a device, Foxglove will
-   skip indexing of a recording if its content hash matches a recording already
-   processed for that device. Without a device link, users can provide a `key`
-   parameter to ensure Foxglove's backend identifies and avoids processing the
-   same upload more than once. Data files for duplicate requests will be written
-   to a deterministic location and thus require no clean up.
+Foxglove's upload APIs use one of two mechanisms to ensure recordings are processed only once:
 
-### Importing your files
-Your self-hosted deployment is connected to object notifications from your
-configured inbox bucket. To import a recording, you will upload it to your inbox
-bucket.
+- Internally, Foxglove creates a unique idempotency key to avoid duplicates after reception.
+- For recordings associated with a device, Foxglove will verify that its content hash doesn't match any other recording already processed for that device before indexing it. For recordings without an associated device, users can provide a unique `key` parameter to help Foxglove avoids processing the same upload more than once. Data files for duplicate requests are written to a deterministic location and thus require no clean up.
 
-To associate your recording with metadata information, there are two available
-mechanisms: object metadata and MCAP metadata. The primary advantage of using
-object metadata is that it is applicable to ROS bag files. For MCAP files, MCAP
-metadata accomplishes the same task while resulting in a more self-contained
-file. The supported metadata keys are,
-* Device name:  The name of a device to associate with the recording. Must match one that exists in Foxglove.
-* Device ID: The ID of a device to associate with the recording. Must match one that exists in Foxglove.
-* Key: An idempotency key to associate with the recording.
+### Adding metadata to imports
+
+Associate your recording with metadata information for more self-contained files:
+
+- **Object metadata** - For ROS bag files
+- **MCAP metadata** – For [MCAP files](https://mcap.dev)
+
+Both types of metadata support the following keys:
+
+- **Device name** – Name of device associated with the recording (must match an existing Foxglove device)
+- **Device ID** – ID of device associated with the recording (must match an existing Foxglove device)
+- **Key** – Idempotency key associated with the recording
+
+If a device ID is specified in both MCAP metadata and object metadata, object metadata will take precedence.
+
+If an MCAP file has more than one metadata record with `name="foxglove"`, the file's last record will take precedence.
 
 #### Object metadata
-If configuring the above with object metadata, use the key names
-`foxglove_device_name`, `foxglove_device_id`, and `foxglove_key`. To ensure that
-your file is not read before your metadata is set, ensure that you set write the
-file and set the metadata in the same operation.
+
+Add object metadata to your files using the following key names:
+
+- `foxglove_device_name`
+- `foxglove_device_id`
+- `foxglove_key`
+
+To ensure that your file is not read before your metadata is set, write the file and set the metadata in the same operation.
 
 #### MCAP metadata
-To accomplish the same with MCAP metadata, add a Metadata record to your MCAP
-file with the name "foxglove", and use the `deviceName`, `deviceId`, or `key`
-values.
 
-Python example:
+Add MCAP metadata to your files using `name="foxglove` and the following key names:
+
+- `deviceName`
+- `deviceId`
+- `key`
+
+An example using [MCAP's Python library](https://mcap.dev/docs/python/):
 
 ```py
 mcap_writer.add_metadata(
@@ -59,15 +60,9 @@ mcap_writer.add_metadata(
 )
 ```
 
-If the device ID is specified in both MCAP metadata and object metadata as documented above, object metadata takes precedence.
-
-If more than one metadata record is present in the MCAP with the name `foxglove`, only the last record in the file will be used.
-
 ### Cloud CLI uploads
 
-The following are some examples of how to upload objects with metadata to the
-various cloud SDKs. You can adapt to your needs according to the directions
-above.
+You can use the command line to upload objects with metadata to various cloud SDKs. Adapt the following examples to your team's unique needs.
 
 #### Microsoft Azure
 

--- a/docs/10-primary-sites/1-self-hosting/1-manage-data.md
+++ b/docs/10-primary-sites/1-self-hosting/1-manage-data.md
@@ -7,42 +7,48 @@ Manage your self-hosted Primary Site's data.
 
 ### Upload data
 
-When uploading data to the inbox bucket, you need to add a `foxglove_device_id` metadata key that corresponds to a device ID in your Foxglove organization.
+To import data to the platform, self-managed users must upload their recordings
+to the inbox bucket using one of the methods below.
 
-Create a device from the [Devices page](https://console.foxglove.dev/devices) or using the CLI's `foxglove devices add` command.
+Once the import is acknowledged by the platform, you will see the pending
+import on the [Recordings page](https://console.foxglove.dev/recordings). Once
+processed, the uploaded data will be available via the API and CLI.
 
-Then, import data for that device according to your cloud provider.
+#### Usage note: Idempotency keys
+Foxglove's upload APIs use one of two mechanisms to ensure recordings are
+processed only once, preventing duplicates.
+1. Internally, Foxglove creates a unique idempotency key to avoid duplicates after reception.
+2. For uploaders, if the recording is associated with a device, Foxglove will
+   skip indexing of a recording if its content hash matches a recording already
+   processed for that device. Without a device link, users can provide a `key`
+   parameter to ensure Foxglove's backend identifies and avoids processing the
+   same upload more than once. Data files for duplicate requests will be written
+   to a deterministic location and thus require no clean up.
 
-#### Microsoft Azure
+#### Importing your files
+Your self-hosted deployment is connected to object notifications from your
+configured inbox bucket. To import a recording, you will upload it to your inbox
+bucket.
 
-```bash
-$ az storage blob upload -f ~/data/bags/gps.bag --container-name inbox --account-name yourorgfgstorage -n gps.bag --overwrite --metadata foxglove_device_id=dev_03ooHzt1GRRdnGrP
-```
+To associate your recording with metadata information, there are two available
+mechanisms: object metadata and MCAP metadata. The primary advantage of using
+object metadata is that it is applicable to ROS bag files. For MCAP files, MCAP
+metadata accomplishes the same task while resulting in a more self-contained
+file. The supported metadata keys are,
+* Device name:  The name of a device to associate with the recording. Must match one that exists in Foxglove.
+* Device ID: The ID of a device to associate with the recording. Must match one that exists in Foxglove.
+* Key: An idempotency key to associate with the recording.
 
-#### Google Cloud Storage
+##### Object metadata
+If configuring the above with object metadata, use the key names
+`foxglove_device_name`, `foxglove_device_id`, and `foxglove_key`. To ensure that
+your file is not read before your metadata is set, ensure that you set write the
+file and set the metadata in the same operation.
 
-```bash
-$ gsutil -h "x-goog-meta-foxglove_device_id:<your device id>" cp <input.bag> gs://<your inbox bucket>/<path>
-```
-
-#### Amazon S3
-
-```bash
-$ aws s3 cp input.bag s3://<inbox-bucket>/<path> --metadata '{"foxglove_device_id": "<your device ID>"}'
-```
-
-You will see the pending import on the [Recordings page](https://console.foxglove.dev/recordings). Once processed, the uploaded data will be available via the API and CLI.
-
-### Specify a device in MCAP metadata
-
-If you are importing MCAP files, you can specify the associated device ID in an [MCAP metadata record](https://mcap.dev/specification/index.html#metadata-op0x0c) rather than in object metadata as described above. You may also specify a device name rather than an ID.
-
-1. Include a metadata record named `foxglove`
-2. In that record, either:
-   - add your device ID with a key of "deviceId"
-   - add your device name with a key of "deviceName"
-
-Note, if referring to a device by name, that the device must be known to Foxglove in advance. If you supply a device name which doesn't have an associated Foxglove ID, your import will fail. Add the device from the [Devices page](https://console.foxglove.dev/devices).
+##### MCAP metadata
+To accomplish the same with MCAP metadata, add a Metadata record to your MCAP
+file with the name "foxglove", and use the `deviceName`, `deviceId`, or `key`
+values.
 
 Python example:
 
@@ -56,3 +62,27 @@ mcap_writer.add_metadata(
 If the device ID is specified in both MCAP metadata and object metadata as documented above, object metadata takes precedence.
 
 If more than one metadata record is present in the MCAP with the name `foxglove`, only the last record in the file will be used.
+
+#### Cloud CLI uploads
+
+The following are some examples of how to upload objects with metadata to the
+various cloud SDKs. You can adapt to your needs according to the directions
+above.
+
+##### Microsoft Azure
+
+```bash
+$ az storage blob upload -f ~/data/bags/gps.bag --container-name inbox --account-name yourorgfgstorage -n gps.bag --overwrite
+```
+
+##### Google Cloud Storage
+
+```bash
+$ gsutil cp <input.bag> gs://<your inbox bucket>/<path>
+```
+
+##### Amazon S3
+
+```bash
+$ aws s3 cp input.bag s3://<inbox-bucket>/<path>
+```

--- a/docs/10-primary-sites/1-self-hosting/1-manage-data.md
+++ b/docs/10-primary-sites/1-self-hosting/1-manage-data.md
@@ -72,17 +72,17 @@ above.
 ##### Microsoft Azure
 
 ```bash
-$ az storage blob upload -f ~/data/bags/gps.bag --container-name inbox --account-name yourorgfgstorage -n gps.bag --overwrite
+$ az storage blob upload -f ~/data/bags/gps.bag --container-name inbox --account-name yourorgfgstorage -n gps.bag --overwrite --metadata foxglove_device_id=dev_03ooHzt1GRRdnGrP
 ```
 
 ##### Google Cloud Storage
 
 ```bash
-$ gsutil cp <input.bag> gs://<your inbox bucket>/<path>
+$ gsutil -h "x-goog-meta-foxglove_device_id:<your device id>" cp <input.bag> gs://<your inbox bucket>/<path>
 ```
 
 ##### Amazon S3
 
 ```bash
-$ aws s3 cp input.bag s3://<inbox-bucket>/<path>
+$ aws s3 cp input.bag s3://<inbox-bucket>/<path> --metadata '{"foxglove_device_id": "<your device ID>"}'
 ```

--- a/docs/10-primary-sites/1-self-hosting/1-manage-data.md
+++ b/docs/10-primary-sites/1-self-hosting/1-manage-data.md
@@ -25,7 +25,7 @@ processed only once, preventing duplicates.
    same upload more than once. Data files for duplicate requests will be written
    to a deterministic location and thus require no clean up.
 
-#### Importing your files
+### Importing your files
 Your self-hosted deployment is connected to object notifications from your
 configured inbox bucket. To import a recording, you will upload it to your inbox
 bucket.
@@ -39,13 +39,13 @@ file. The supported metadata keys are,
 * Device ID: The ID of a device to associate with the recording. Must match one that exists in Foxglove.
 * Key: An idempotency key to associate with the recording.
 
-##### Object metadata
+#### Object metadata
 If configuring the above with object metadata, use the key names
 `foxglove_device_name`, `foxglove_device_id`, and `foxglove_key`. To ensure that
 your file is not read before your metadata is set, ensure that you set write the
 file and set the metadata in the same operation.
 
-##### MCAP metadata
+#### MCAP metadata
 To accomplish the same with MCAP metadata, add a Metadata record to your MCAP
 file with the name "foxglove", and use the `deviceName`, `deviceId`, or `key`
 values.
@@ -63,25 +63,25 @@ If the device ID is specified in both MCAP metadata and object metadata as docum
 
 If more than one metadata record is present in the MCAP with the name `foxglove`, only the last record in the file will be used.
 
-#### Cloud CLI uploads
+### Cloud CLI uploads
 
 The following are some examples of how to upload objects with metadata to the
 various cloud SDKs. You can adapt to your needs according to the directions
 above.
 
-##### Microsoft Azure
+#### Microsoft Azure
 
 ```bash
 $ az storage blob upload -f ~/data/bags/gps.bag --container-name inbox --account-name yourorgfgstorage -n gps.bag --overwrite --metadata foxglove_device_id=dev_03ooHzt1GRRdnGrP
 ```
 
-##### Google Cloud Storage
+#### Google Cloud Storage
 
 ```bash
 $ gsutil -h "x-goog-meta-foxglove_device_id:<your device id>" cp <input.bag> gs://<your inbox bucket>/<path>
 ```
 
-##### Amazon S3
+#### Amazon S3
 
 ```bash
 $ aws s3 cp input.bag s3://<inbox-bucket>/<path> --metadata '{"foxglove_device_id": "<your device ID>"}'

--- a/docs/4-importing-data.md
+++ b/docs/4-importing-data.md
@@ -9,7 +9,7 @@ Check out the [MCAP docs](https://mcap.dev) for more information on [converting 
 
 ### (Optional) Add devices
 
-If your recordings are associated with devices, you must create uniquely named devices for every real or simulated robot you want to track. This will allow your team members to add data recorded on these devices.
+To organize files by the robot they were recorded on, create uniquely named devices for every real or simulated robot you want to track. Files do not have to be associated with a device to import them.
 
 Click "Add device" on the [Devices page](https://console.foxglove.dev/devices) to create your devices:
 
@@ -17,7 +17,7 @@ Click "Add device" on the [Devices page](https://console.foxglove.dev/devices) t
 
 ### Import files
 
-Click the "Import data" button on the [Recordings](https://console.foxglove.dev/recordings) or [Timeline](https://console.foxglove.dev/timeline) page:
+Import data from the [Recordings](https://console.foxglove.dev/recordings) or [Timeline](https://console.foxglove.dev/timeline) page:
 
 ![Recordings page](/img/docs/recordings/index.png)
 

--- a/docs/4-importing-data.md
+++ b/docs/4-importing-data.md
@@ -7,9 +7,9 @@ Import [ROS 1](/docs/connecting-to-data/frameworks/ros1#imported-data) (`.bag`) 
 
 Check out the [MCAP docs](https://mcap.dev) for more information on [converting other data formats](https://foxglove.dev/blog/importing-your-ros2-data-into-foxglove-data-platform) – like ROS 2, Protobuf, JSON, and more – into the MCAP file format.
 
-### Add devices
+### (Optional) Add devices
 
-Before importing data, you must create uniquely named devices for every real or simulated robot you want to track. This will allow your team members to add data recorded on these devices. All imported files must be associated with a corresponding device.
+If your recordings are associated with devices, you must create uniquely named devices for every real or simulated robot you want to track. This will allow your team members to add data recorded on these devices.
 
 Click "Add device" on the [Devices page](https://console.foxglove.dev/devices) to create your devices:
 
@@ -23,7 +23,7 @@ Click the "Import data" button on the [Recordings](https://console.foxglove.dev/
 
 Alternatively, you can click on one of your created devices on the [Devices page](https://console.foxglove.dev/devices) to go to its details page – from there, you can import data directly to that device.
 
-Select the file you want to import, as well as the device you want to associate with the recording:
+Select the file you want to import, and the device you want to associate with the recording if desired:
 
 ![import](/img/docs/importing-data/import.webp)
 


### PR DESCRIPTION
This updates the documentation to support recordings without devices, including describing the purpose of the new "key" parameter and its role.

This includes a restructuring of the self-managed data uploading documentation. The API document updates are in a separate PR (that will make their descriptions public).