### PR TITLE
Add troubleshooting section to 3D panel transforms

### DIFF
--- a/docs/3-visualization/4-panels/3d.md
+++ b/docs/3-visualization/4-panels/3d.md
@@ -321,7 +321,7 @@ Transform preloading in the 3D panel ensures an accurate scene by loading transf
 
 #### Troubleshooting
 
-When working with live sources where time synchronicity cannot be achieved, it is recommended to have the server publish it's `Time` according to the [Foxglove Websocket Protocol](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#time). Otherwise if the server time is ahead of the visualization app, certain messages in the 3D panel will display immediately but coordinate frame state would lag behind as it tries to use its own wall time instead of the servers'.
+When working with live sources where time synchronicity cannot be achieved, it is recommended to have the server publish it's `Time` according to the [Foxglove Websocket Protocol](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#time). Otherwise if the server time is ahead of the visualization app, certain messages in the 3D panel will display immediately but coordinate frame state can lag behind as the app uses its wall time instead of the server time.
 
 #### Settings
 

--- a/docs/3-visualization/4-panels/3d.md
+++ b/docs/3-visualization/4-panels/3d.md
@@ -319,6 +319,10 @@ The panel stores coordinate frame relationships over time in a transform history
 
 Transform preloading in the 3D panel ensures an accurate scene by loading transform messages into memory. Transform preloading may impact 3D panel performance during preloading and seeking. You can disable preloading in the 3D panel settings. However, when disabled, the 3D panel may not properly render your scene in certain circumstances where infrequent coordinate frames are involved.
 
+#### Troubleshooting
+
+When working with live sources where time synchronicity cannot be achieved, it is recommended to have the server publish it's `Time` according to the [Foxglove Websocket Protocol](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md#time). Otherwise if the server time is ahead of the visualization app, certain messages in the 3D panel will display immediately but coordinate frame state would lag behind as it tries to use its own wall time instead of the servers'.
+
 #### Settings
 
 | field                 | description                                                                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
Added a troubleshooting section to the docs to explain issue for live connections with asynchronicity between server and client.

Fixes: FG-5229