### PR TITLE
webhooks: update badges to require team or enterprise plan

### DIFF
--- a/docs/13-webhooks/0-introduction.md
+++ b/docs/13-webhooks/0-introduction.md
@@ -5,7 +5,7 @@ description: Webhooks notify your software when events happen within your Foxglo
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Closed Beta, contact us for access" />
+<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
 
 Webhooks notify your software when events happen within your Foxglove organization.
 

--- a/docs/13-webhooks/1-getting-started.md
+++ b/docs/13-webhooks/1-getting-started.md
@@ -5,7 +5,7 @@ description: Set up your first webhook.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Closed Beta, contact us for access" />
+<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
 
 ### Prerequisites
 

--- a/docs/13-webhooks/2-security.md
+++ b/docs/13-webhooks/2-security.md
@@ -5,7 +5,7 @@ description: Secure your webhook endpoint.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Closed Beta, contact us for access" />
+<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
 
 Secure your webhook endpoint.
 


### PR DESCRIPTION
### Public-Facing Changes

Updates webhooks from being in closed beta to a team or enterprise plan feature.

### Description

<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
