### PR TITLE
Document adding files to agent storage

### DIFF
--- a/docs/12-foxglove-agent/2-manage-data.md
+++ b/docs/12-foxglove-agent/2-manage-data.md
@@ -9,17 +9,17 @@ import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequir
 
 Start processing data recordings with your Foxglove Agent.
 
-### Set up directory
+### Set up the data directory
 
-Configure the `STORAGE_ROOT` setting in `/etc/foxglove/agent/envfile` with the directory you want to monitor for newly recorded data files.
+Configure the `STORAGE_ROOT` setting in `/etc/foxglove/agent/envfile` with the directory you want to monitor for newly recorded data files. This will serve as the Agent's _data directory_.
 
 ### Adding recording files
 
-Move your completed recordings into the `STORAGE_ROOT`. The Agent will be notified by the filesystem when a new recording is available.
+Move your completed recordings into the data directory. The Agent will be notified by the filesystem when a new recording is available.
 
-The Foxglove Agent receives filesystem notifications when files are created in the data directory. This notification is triggered when a file is created. To avoid triggering notifications on incomplete files, data files should be [renamed](https://man7.org/linux/man-pages/man1/rename.1.html) into the `STORAGE_ROOT` directory after writing (use `mv` rather than `cp`). Alternatively, you can write files into the `STORAGE_ROOT` directory with an ignored filename suffix, and then rename it to remove the suffix after writing. The ignored suffix defaults to `.active` and can be customized with the `WATCH_IGNORE_SUFFIX` environment variable.
+The Foxglove Agent receives filesystem notifications when files are created in the data directory. This notification is triggered when a file is created. To avoid triggering notifications on incomplete files, data files should be [renamed](https://man7.org/linux/man-pages/man1/rename.1.html) into the data directory after writing (use `mv` rather than `cp`). Alternatively, you can write files into the data directory with an ignored filename suffix, and then rename it to remove the suffix after writing. The ignored suffix defaults to `.active` and can be customized with the `WATCH_IGNORE_SUFFIX` environment variable.
 
-**Note:** The ROS 1 bag writer uses an `.active` suffix on incomplete files by default, and can be used to write directly into the `STORAGE_ROOT`.
+**Note:** The ROS 1 bag writer uses an `.active` suffix on incomplete files by default, and can be used to write directly into the data directory.
 
 ### Import to cloud
 

--- a/docs/12-foxglove-agent/2-manage-data.md
+++ b/docs/12-foxglove-agent/2-manage-data.md
@@ -13,6 +13,12 @@ Start processing data recordings with your Foxglove Agent.
 
 Configure the `STORAGE_ROOT` setting in `/etc/foxglove/agent/envfile` with the directory you want to monitor for newly recorded data files.
 
+### Adding recording files
+
+Move your completed recordings into the `STORAGE_ROOT`. The Agent will be notified by the filesystem when a new recording is available.
+
+You should take care that the file contents are complete when the create notification occurs. For example, you should not stream log data directly to an mcap file in the storage root. You should also move (`mv`) files into place rather than copy (`cp`) them. If using ROS1, this is handled correctly for you because recordings are written to an ".active" file, and the Agent ignores the "active" suffix by default.
+
 ### Import to cloud
 
 Recordings for your device will initially appear in the [Recordings page](https://console.foxglove.dev/recordings). In order to visualize and download this data, you can select these recordings and click "Import". Once the import status is displayed as "complete", the recording is available. You can also do this with the [Recordings API](https://docs.foxglove.dev/api/#tag/Recordings/paths/~1recordings~1%7Bid%7D~1import/post).

--- a/docs/12-foxglove-agent/2-manage-data.md
+++ b/docs/12-foxglove-agent/2-manage-data.md
@@ -17,7 +17,9 @@ Configure the `STORAGE_ROOT` setting in `/etc/foxglove/agent/envfile` with the d
 
 Move your completed recordings into the `STORAGE_ROOT`. The Agent will be notified by the filesystem when a new recording is available.
 
-You should take care that the file contents are complete when the create notification occurs. For example, you should not stream log data directly to an mcap file in the storage root. You should also move (`mv`) files into place rather than copy (`cp`) them. If using ROS1, this is handled correctly for you because recordings are written to an ".active" file, and the Agent ignores the "active" suffix by default.
+The Foxglove Agent receives filesystem notifications when files are created in the data directory. This notification is triggered when a file is created. To avoid triggering notifications on incomplete files, data files should be [renamed](https://man7.org/linux/man-pages/man1/rename.1.html) into the `STORAGE_ROOT` directory after writing (use `mv` rather than `cp`). Alternatively, you can write files into the `STORAGE_ROOT` directory with an ignored filename suffix, and then rename it to remove the suffix after writing. The ignored suffix defaults to `.active` and can be customized with the `WATCH_IGNORE_SUFFIX` environment variable.
+
+**Note:** The ROS 1 bag writer uses an `.active` suffix on incomplete files by default, and can be used to write directly into the `STORAGE_ROOT`.
 
 ### Import to cloud
 


### PR DESCRIPTION
### Public-Facing Changes

This adds a section to the Agent docs on adding recordings. This clarifies the expectations for completeness to avoid transient errors like that described in FG-5890.
