### PR TITLE
Add namespace to commands

### DIFF
--- a/docs/10-primary-sites/1-self-hosting/2-configure-cloud-credentials.md
+++ b/docs/10-primary-sites/1-self-hosting/2-configure-cloud-credentials.md
@@ -62,7 +62,7 @@ stringData:
 Example application of a secrets file:
 
 ```shell
-$ kubectl apply -f ./cloud-credentials-secret.yaml
+$ kubectl apply -f ./cloud-credentials-secret.yaml -n foxglove
 ```
 
 ## S3-Compatible
@@ -90,7 +90,7 @@ stringData:
 Example application of a secrets file:
 
 ```shell
-$ kubectl apply -f ./cloud-credentials-secret.yaml
+$ kubectl apply -f ./cloud-credentials-secret.yaml -n foxglove
 ```
 
 ## Azure
@@ -117,5 +117,5 @@ stringData:
 Example application of a secrets file:
 
 ```shell
-$ kubectl apply -f ./cloud-credentials-secret.yaml
+$ kubectl apply -f ./cloud-credentials-secret.yaml -n foxglove
 ```

--- a/docs/11-edge-sites/2-configure-cloud-credentials.mdx
+++ b/docs/11-edge-sites/2-configure-cloud-credentials.mdx
@@ -44,7 +44,7 @@ stringData:
 Example application of a secrets file:
 
 ```shell
-$ kubectl apply -f ./cloud-credentials-secret.yaml
+$ kubectl apply -f ./cloud-credentials-secret.yaml -n foxglove
 ```
 
 ### Azure
@@ -71,5 +71,5 @@ stringData:
 Example application of a secrets file:
 
 ```shell
-$ kubectl apply -f ./cloud-credentials-secret.yaml
+$ kubectl apply -f ./cloud-credentials-secret.yaml -n foxglove
 ```


### PR DESCRIPTION
Feedback from a user: our 'secrets' commands didn't include the namespace. This adds it.