### PR TITLE
Document some limits for free plans

### DIFF
--- a/docs/6-devices.md
+++ b/docs/6-devices.md
@@ -3,9 +3,13 @@ title: Devices
 description: Devices represent every real and simulated robot that your organization wants to track.
 ---
 
+import AccountRequiredHeader from "../src/components/docs/icons/AccountRequiredHeader";
+
 Devices represent every real and simulated robot that your organization wants to track.
 
 When importing data into Foxglove, you can associate each data recording with the device that recorded it.
+
+On the free plan, your organization may create up to ten devices.
 
 ### Actions
 
@@ -18,6 +22,8 @@ Add, list, delete, and search devices from the [Devices page](https://console.fo
 | **Delete** | Delete a device in your organization                                         | `foxglove devices delete --name "my device"` |
 
 ### Custom properties
+
+<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
 
 Custom properties are predefined metadata fields that can be associated with a device. They are set by admins for their organization.
 

--- a/docs/6-devices.mdx
+++ b/docs/6-devices.mdx
@@ -23,7 +23,7 @@ Add, list, delete, and search devices from the [Devices page](https://console.fo
 
 ### Custom properties
 
-<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Custom properties are predefined metadata fields that can be associated with a device. They are set by admins for their organization.
 


### PR DESCRIPTION
This makes note of a couple of limitations in the new free plan, which is now in effect (https://github.com/foxglove/app/pull/5575).

The new free plan is described by the pricing updates in https://github.com/foxglove/website/pull/1244 with the latest preview at https://website-g73j8cil3.foxglove.party/pricing.

Free plans are also now granted storage and can upload & stream. I don't think this restriction was noted in the documentation before, because we start orgs on the "team trial" plan today.