### PR TITLE
show badges for individual plans per feature

### DIFF
--- a/docs/1-organization-setup/3-okta-sso.mdx
+++ b/docs/1-organization-setup/3-okta-sso.mdx
@@ -4,7 +4,7 @@ title: Okta SSO
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Enterprise plan" />
+<AccountRequiredHeader plans={["Enterprise"]} />
 
 Foxglove organizations can use Okta as authorization provider.
 
@@ -39,11 +39,11 @@ Configure application settings on the [Okta SSO settings page](https://console.f
 
 - **Okta domain** – Find in the Okta dashboard's profile dropdown (`xxxxx.okta.com`)
 
-  <img alt="Okta domain" src="/img/docs/organization-setup/okta/domain.png" width="400"/>
+  <img alt="Okta domain" src="/img/docs/organization-setup/okta/domain.png" width="400" />
 
 - **Client ID** – Find in the Applications list, below the app name
 
-  <img alt="Okta clientId" src="/img/docs/organization-setup/okta/clientid.png" width="600"/>
+  <img alt="Okta clientId" src="/img/docs/organization-setup/okta/clientid.png" width="600" />
 
 ### (Optional) Disable non-Okta sign in
 

--- a/docs/10-primary-sites/0-introduction.mdx
+++ b/docs/10-primary-sites/0-introduction.mdx
@@ -13,7 +13,7 @@ When you sign up for a Foxglove organization, you are assigned a Foxglove-hosted
 
 ### Self-hosted
 
-<AccountRequiredHeader badgeText="Requires Enterprise plan" />
+<AccountRequiredHeader plans={["Enterprise"]} />
 
 Set up a self-hosted Primary Site to store and access robotics data with your own cloud storage solution.
 

--- a/docs/11-edge-sites/0-introduction.mdx
+++ b/docs/11-edge-sites/0-introduction.mdx
@@ -5,7 +5,7 @@ description: Edge Sites are on-site data storage centers, located in physical pr
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Enterprise plan" />
+<AccountRequiredHeader plans={["Enterprise"]} />
 
 Edge Sites are on-site data storage centers, located in physical proximity to where your robots are operating. They are designed to safely store data on-premises before you decide to forward it to the cloud, mitigating the risks of unpredictable network connectivity or low bandwidth. Whether your robots operate in a warehouse, farm field, or garage, Edge Sites help you pull your data on-demand from these resource-constrained environments for further analysis.
 

--- a/docs/12-foxglove-agent/0-introduction.mdx
+++ b/docs/12-foxglove-agent/0-introduction.mdx
@@ -5,7 +5,7 @@ description: The Foxglove Agent runs on a device and monitors a designated direc
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 The Foxglove Agent runs on a device and monitors a designated directory in its filesystem for newly recorded data files.
 

--- a/docs/12-foxglove-agent/1-installation.mdx
+++ b/docs/12-foxglove-agent/1-installation.mdx
@@ -5,7 +5,7 @@ description: Install and configure the Foxglove Agent.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Install and configure the Foxglove Agent.
 

--- a/docs/12-foxglove-agent/2-manage-data.mdx
+++ b/docs/12-foxglove-agent/2-manage-data.mdx
@@ -5,7 +5,7 @@ description: Start processing data recordings with your Foxglove Agent.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Start processing data recordings with your Foxglove Agent.
 

--- a/docs/13-webhooks/0-introduction.mdx
+++ b/docs/13-webhooks/0-introduction.mdx
@@ -5,7 +5,7 @@ description: Webhooks notify your software when events happen within your Foxglo
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Webhooks notify your software when events happen within your Foxglove organization.
 

--- a/docs/13-webhooks/1-getting-started.mdx
+++ b/docs/13-webhooks/1-getting-started.mdx
@@ -5,7 +5,7 @@ description: Set up your first webhook.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 ### Prerequisites
 

--- a/docs/13-webhooks/2-security.mdx
+++ b/docs/13-webhooks/2-security.mdx
@@ -5,7 +5,7 @@ description: Secure your webhook endpoint.
 
 import AccountRequiredHeader from "../../src/components/docs/icons/AccountRequiredHeader";
 
-<AccountRequiredHeader badgeText="Requires Team or Enterprise plan" />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Secure your webhook endpoint.
 

--- a/docs/3-visualization/3-layouts.mdx
+++ b/docs/3-visualization/3-layouts.mdx
@@ -11,7 +11,7 @@ A perception engineer may develop layouts for calibrating various sensors, a pla
 
 Use the "Layouts" menu to create, edit, and share layouts.
 
-<img alt="Layouts menu" src="/img/docs/visualization/organization-layouts.png" width="300"/>
+<img alt="Layouts menu" src="/img/docs/visualization/organization-layouts.png" width="300" />
 
 ### Personal layouts
 
@@ -34,7 +34,11 @@ When switching layouts after making edits to your current personal layout, you c
 - **"Save changes"** – Save your changes to the layout
 - **"Revert"** – Discard changes and revert to the last explicitly saved layout version
 
-<img alt="Modified personal layout menu" src="/img/docs/visualization/modified-personal-layout.png" width="400"/>
+<img
+  alt="Modified personal layout menu"
+  src="/img/docs/visualization/modified-personal-layout.png"
+  width="400"
+/>
 
 #### Import and export
 
@@ -58,13 +62,17 @@ To perform a batch action on multiple layouts:
 
 ### Organization layouts
 
-<AccountRequiredHeader />
+<AccountRequiredHeader plans={["Team", "Enterprise"]} />
 
 Organization layouts allow teams to curate a set of canonical layouts to accomplish common tasks – e.g. for calibrating radar sensors, visualizing planning algorithm outputs, or viewing logs. Instead of maintaining marginally different setups for different tasks, teammates can use layouts preconfigured by workflow experts to avoid redundant work and accelerate development.
 
 Organization layouts work very similarly to personal layouts – i.e. you can rename, copy, export, and delete them – but operate more as templates than evolving snapshots of a workspace.
 
-<img alt="Modified team layout menu" src="/img/docs/visualization/modified-team-layout.png" width="400"/>
+<img
+  alt="Modified team layout menu"
+  src="/img/docs/visualization/modified-team-layout.png"
+  width="400"
+/>
 
 #### Edit
 
@@ -80,4 +88,9 @@ Use a personal layout's context menu to "Share with team..." – this will make 
 
 Organization layouts can be edited, renamed, or deleted by any team member.
 x
-<img alt="Organization layouts" src="/img/docs/visualization/organization-layouts.png" width="300"/>
+
+<img
+  alt="Organization layouts"
+  src="/img/docs/visualization/organization-layouts.png"
+  width="300"
+/>

--- a/docs/3-visualization/3-layouts.mdx
+++ b/docs/3-visualization/3-layouts.mdx
@@ -62,8 +62,6 @@ To perform a batch action on multiple layouts:
 
 ### Organization layouts
 
-<AccountRequiredHeader plans={["Team", "Enterprise"]} />
-
 Organization layouts allow teams to curate a set of canonical layouts to accomplish common tasks – e.g. for calibrating radar sensors, visualizing planning algorithm outputs, or viewing logs. Instead of maintaining marginally different setups for different tasks, teammates can use layouts preconfigured by workflow experts to avoid redundant work and accelerate development.
 
 Organization layouts work very similarly to personal layouts – i.e. you can rename, copy, export, and delete them – but operate more as templates than evolving snapshots of a workspace.

--- a/docs/3-visualization/8-extensions/3-publish.mdx
+++ b/docs/3-visualization/8-extensions/3-publish.mdx
@@ -22,7 +22,7 @@ When you're ready to distribute your extension, run `npm run package` to produce
 
 ## Sharing with your team
 
-<AccountRequiredHeader badgeText="Requires Team plan or above" />
+<AccountRequiredHeader plans={["Free", "Team", "Enterprise"]} />
 
 Publish your extension [with the `foxglove` CLI](https://github.com/foxglove/foxglove-cli#foxglove-cli) for the rest of your organization to use in Foxglove:
 

--- a/src/components/docs/icons/AccountRequiredHeader.tsx
+++ b/src/components/docs/icons/AccountRequiredHeader.tsx
@@ -1,29 +1,44 @@
 import React, { ReactElement } from "react";
 
-function Badge({ badgeText }: { badgeText?: string }): ReactElement {
+type PlanName = "Free" | "Starter" | "Team" | "Enterprise";
+
+function Badge({ plan }: { plan: PlanName }): ReactElement {
   return (
     <p>
-      <div
-        style={{
-          color: "rgba(139, 92, 246, 1)",
-          display: "flex",
-          alignItems: "center",
-          fontSize: "11px",
-        }}
-      >
-        <svg fill="currentColor" viewBox="0 0 24 24" width="24" height="24">
-          <path d="M9 10A3.04 3.04 0 0 1 12 7A3.04 3.04 0 0 1 15 10A3.04 3.04 0 0 1 12 13A3.04 3.04 0 0 1 9 10M12 19L16 20V16.92A7.54 7.54 0 0 1 12 18A7.54 7.54 0 0 1 8 16.92V20M12 4A5.78 5.78 0 0 0 7.76 5.74A5.78 5.78 0 0 0 6 10A5.78 5.78 0 0 0 7.76 14.23A5.78 5.78 0 0 0 12 16A5.78 5.78 0 0 0 16.24 14.23A5.78 5.78 0 0 0 18 10A5.78 5.78 0 0 0 16.24 5.74A5.78 5.78 0 0 0 12 4M20 10A8.04 8.04 0 0 1 19.43 12.8A7.84 7.84 0 0 1 18 15.28V23L12 21L6 23V15.28A7.9 7.9 0 0 1 4 10A7.68 7.68 0 0 1 6.33 4.36A7.73 7.73 0 0 1 12 2A7.73 7.73 0 0 1 17.67 4.36A7.68 7.68 0 0 1 20 10Z" />
-        </svg>
-        <a href="https://foxglove.dev/pricing">
-          <span style={{ color: "rgba(139, 92, 246, 1)" }}>
-            {badgeText ?? "Requires Team or Enterprise plan"}
-          </span>
-        </a>
-      </div>
+      <a href="https://foxglove.dev/pricing">
+        <div
+          style={{
+            color: "rgba(139, 92, 246, 1)",
+            display: "flex",
+            alignItems: "center",
+            fontSize: "11px",
+            margin: "0 0 0 12px",
+          }}
+        >
+          <svg fill="currentColor" viewBox="0 0 24 24" width="24" height="24">
+            <path d="M9 10A3.04 3.04 0 0 1 12 7A3.04 3.04 0 0 1 15 10A3.04 3.04 0 0 1 12 13A3.04 3.04 0 0 1 9 10M12 19L16 20V16.92A7.54 7.54 0 0 1 12 18A7.54 7.54 0 0 1 8 16.92V20M12 4A5.78 5.78 0 0 0 7.76 5.74A5.78 5.78 0 0 0 6 10A5.78 5.78 0 0 0 7.76 14.23A5.78 5.78 0 0 0 12 16A5.78 5.78 0 0 0 16.24 14.23A5.78 5.78 0 0 0 18 10A5.78 5.78 0 0 0 16.24 5.74A5.78 5.78 0 0 0 12 4M20 10A8.04 8.04 0 0 1 19.43 12.8A7.84 7.84 0 0 1 18 15.28V23L12 21L6 23V15.28A7.9 7.9 0 0 1 4 10A7.68 7.68 0 0 1 6.33 4.36A7.73 7.73 0 0 1 12 2A7.73 7.73 0 0 1 17.67 4.36A7.68 7.68 0 0 1 20 10Z" />
+          </svg>
+
+          <span style={{ color: "rgba(139, 92, 246, 1)" }}>{plan}</span>
+        </div>
+      </a>
     </p>
   );
 }
 
-export default function AccountRequiredHeader({ badgeText }: { badgeText?: string }): ReactElement {
-  return <Badge badgeText={badgeText} />;
+export default function AccountRequiredHeader({ plans }: { plans: PlanName[] }): ReactElement {
+  if (plans?.length === 0) {
+    return <></>;
+  }
+  return (
+    <div
+      style={{
+        display: "flex",
+      }}
+    >
+      {plans.map((plan, index) => (
+        <Badge plan={plan} key={index} />
+      ))}
+    </div>
+  );
 }


### PR DESCRIPTION
### Public-Facing Changes

Updated the docs with better badges to define which features are supported by which plans

### Description

With the new pricing plans, we needed to update the docs to reflect the feature/plan matrix. In doing these updates, we changed the badge display to badges per supported plan.

<img width="395" alt="Screenshot 2024-03-06 at 10 29 22 AM" src="https://github.com/foxglove/docs/assets/158072430/81f59fc6-8356-4e31-a3ac-b16af25c3948">
<img width="818" alt="Screenshot 2024-03-06 at 10 29 05 AM" src="https://github.com/foxglove/docs/assets/158072430/b5e3b177-e625-480d-9e0d-60e944211924">
<img width="555" alt="Screenshot 2024-03-06 at 10 28 52 AM" src="https://github.com/foxglove/docs/assets/158072430/e0168ff2-2eb1-4c6f-8c17-bbb8bca59bdb">
