### PR TITLE
Add self-managed prerequisite

### DIFF
--- a/docs/12-foxglove-agent/1-installation.mdx
+++ b/docs/12-foxglove-agent/1-installation.mdx
@@ -15,6 +15,7 @@ Install and configure the Foxglove Agent.
 - HTTPS connectivity to `api.foxglove.dev` (stable connection not required)
 - The filesystem hosting your recordings storage directory must support `fsnotify`
 - Directory for storing local state files
+- For self-managed customers, connectivity to your primary site's inbox bucket
 
 ### Create a device and device token
 


### PR DESCRIPTION
This updates the Agent docs, adding a prerequisite for self-managed customers — the agent will need access to the primary inbox bucket.