### PR TITLE
Sync annotations not supported for video topics

### DIFF
--- a/docs/3-visualization/4-panels/image.md
+++ b/docs/3-visualization/4-panels/image.md
@@ -90,7 +90,7 @@ Foxglove supports distortion models `plumb_bob` and `rational_polynomial`.
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **Topic**            | Camera image or video topic to display                                                                                                                                         |
 | **Calibration**      | Calibration topic to use for distortion and 3D markers                                                                                                                         |
-| **Sync annotations** | Display images and 2D annotations only when their messages' timestamps match. Newly received 2D annotation messages will be buffered until a matching set can be displayed.    |
+| **Sync annotations** | Display images and 2D annotations only when their messages' timestamps match. Newly received 2D annotation messages will be buffered until a matching set can be displayed. Not yet supported for `CompressedVideo` topics.    |
 | **Flip horizontal**  | Flip image horizontally over a vertical axis                                                                                                                                   |
 | **Flip vertical**    | Flip image vertically over a horizontal axis                                                                                                                                   |
 | **Rotation**         | Rotate image by 90°, 180°, or 270°                                                                                                                                             |


### PR DESCRIPTION
### Public-Facing Changes

<!-- describe any changes to the public interface or APIs, or write "None" -->
 - Sync annotations not supported for video topics

### Description


<!-- describe what has changed, and motivation behind those changes -->

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->
PR that removes capability: https://github.com/foxglove/app/pull/5818